### PR TITLE
fix speedtest.js userDataDir for #34

### DIFF
--- a/linux/speedtest.js
+++ b/linux/speedtest.js
@@ -18,7 +18,7 @@ var url = process.argv[2];
 (async () => {
   const browser = await puppeteer.launch({
                           executablePath: '/usr/bin/chromium-browser',
-                          userDataDir: '/dev/null',
+                          userDataDir: '/tmp',
                           args: ['--no-sandbox']});
   const page = await browser.newPage();
   await page.setDefaultNavigationTimeout(100000);


### PR DESCRIPTION
works fine in my environment.
```
$ node speedtest.js "https://inonius.net/speedtest/?ispInfo=false"
IPv6_RTT:3.10
IPv6_JIT:0.33
IPv6_DL:974
IPv6_UL:762
IPv4_RTT:3.50
IPv4_JIT:0.22
IPv4_DL:997
IPv4_UL:995
```